### PR TITLE
Also test separator unified path

### DIFF
--- a/lib/rules/invalid-regex-rule.js
+++ b/lib/rules/invalid-regex-rule.js
@@ -105,8 +105,8 @@ function createReplacement(replacement) {
   return () => undefined
 }
 
-function checkPatterns(fileName, source, patterns, report) {
-  patterns.forEach(pattern => shouldCheck(pattern.files, fileName) &&
+function checkPatterns(fileNames, source, patterns, report) {
+  patterns.forEach(pattern => shouldCheck(pattern.files, fileNames) &&
     checkRegex(source, pattern, createReplacement(pattern.details.replacement), report))
 }
 

--- a/lib/rules/required-regex-rule.js
+++ b/lib/rules/required-regex-rule.js
@@ -6,9 +6,9 @@ const { shouldCheck } = require('../utils/check-utils.js')
 
 const { REGEX_FLAGS_FIELD_DEFINITION, FILES_FIELD_DEFINITION } = require('./common-fields-definitions.js')
 
-function checkPatterns(fileName, source, patterns, report, node) {
+function checkPatterns(fileNames, source, patterns, report, node) {
   patterns.forEach(pattern => {
-    if (shouldCheck(pattern.files, fileName) && !pattern.regex.test(source)) {
+    if (shouldCheck(pattern.files, fileNames) && !pattern.regex.test(source)) {
       report({
         node,
         message: formatReportMessage(

--- a/lib/utils/check-utils.js
+++ b/lib/utils/check-utils.js
@@ -3,9 +3,12 @@
 
 /**
  * @param {{ignore: RegExp, inspect: RegExp} | false} [files] Patterns that indicate which files to inspect and which to ignore.
- * @param {string} fileName Name of the file.
+ * @param {[string, string]} fileNames Name of the file in array, the original path followed by a separator unified path.
  * @returns {boolean} true if the file should be checked.
  */
-module.exports.shouldCheck = function (files, fileName) {
-  return !files || (!files.ignore.test(fileName) && files.inspect.test(fileName))
+module.exports.shouldCheck = function (files, fileNames) {
+    const [fileName, unfFileName] = fileNames
+    return !files ||
+        (!(files.ignore.test(fileName) || files.ignore.test(unfFileName)) &&
+            (files.inspect.test(fileName) || files.inspect.test(unfFileName)))
 }

--- a/lib/utils/create-utils.js
+++ b/lib/utils/create-utils.js
@@ -8,8 +8,10 @@ module.exports.buildCreateFunction = function (checkPatterns) {
     return {
       Program: function (node) {
         const fileName = context.getFilename()
-        if (!options.ignoreFilePattern.test(context.getFilename())) {
-          checkPatterns(fileName, context.getSourceCode(node).getText(), options.patterns, context.report, node)
+        const unfFileName = fileName.replaceAll('\\', '/')
+        const fileNames = [fileName, unfFileName]
+        if (!(options.ignoreFilePattern.test(fileName) && options.ignoreFilePattern.test(unfFileName))) {
+          checkPatterns(fileNames, context.getSourceCode(node).getText(), options.patterns, context.report, node)
         }
       }
     }


### PR DESCRIPTION
Since ESLint return the path in os format, so ignore regexp need to handle both `\` and `/` as a separator. Consider this rule:
```js
{
  regex: 'regA',
  files: {
    ignore: '^.*dirA/dirB/dirC/file\\.ts.*',
  },
},
```
It work on mac or linux, but not windows because `...\dirA\dirB\DirC\file.ts` does not match `^.*dirA/dirB/dirC/file\\.ts.*`. We need to change ignore regexp to `^.*dirA[\\\\/]dirB[\\\\/]dirC[\\\\/]file\\.ts.*` in order to support windows also. It is hard to read and easy to forget when a developer is working on mac or linux.

Therefore, I created this PR. now regexp not only test for original path but also a "unified" path ( all `\` are replaced to `/` ).